### PR TITLE
chore: Document Prefix Remove from Column Names

### DIFF
--- a/dz_mongodb/sync_strategies/full_table.py
+++ b/dz_mongodb/sync_strategies/full_table.py
@@ -30,7 +30,7 @@ def get_max_id_value(collection: Collection) -> Optional[str]:
     return None
 
 
-def sync_collection(collection: Collection, stream: Dict, state: Dict) -> None:
+def sync_collection(collection: Collection, stream: Dict, state: Dict,document_remove:bool = False) -> None:
     """
     Sync collection records incrementally
     Args:
@@ -109,7 +109,8 @@ def sync_collection(collection: Collection, stream: Dict, state: Dict) -> None:
                                                              row=row,
                                                              time_extracted=utils.now(),
                                                              time_deleted=None,
-                                                             version=stream_version))
+                                                             version=stream_version,
+                                                             document_remove=document_remove))
 
             state = singer.write_bookmark(state,
                                           stream['tap_stream_id'],

--- a/dz_mongodb/sync_strategies/incremental.py
+++ b/dz_mongodb/sync_strategies/incremental.py
@@ -43,6 +43,7 @@ def update_bookmark(row: Dict, state: Dict, tap_stream_id: str, replication_key_
 def sync_collection(collection: Collection,
                     stream: Dict,
                     state: Optional[Dict],
+                    document_remove:bool = False
                     ) -> None:
     """
     Syncs the stream records incrementally
@@ -107,7 +108,7 @@ def sync_collection(collection: Collection,
                                                              row=row,
                                                              time_extracted=utils.now(),
                                                              time_deleted=None,
-                                                             version=stream_version))
+                                                             version=stream_version,document_remove=document_remove))
             rows_saved += 1
 
             update_bookmark(row, state, stream['tap_stream_id'], replication_key_name)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
     long_desc = fh.read()
 
 setup(name='dz-mongodb',
-      version='1.4.1',
+      version='1.4.2',
       description='Singer.io tap for extracting data from MongoDB - Datazip compatible',
       long_description=long_desc,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
# Problem
(write a short description here or paste a link to JIRA)
Document prefix being attached to each column name in a stream

# Solution
(write a short description here or paste a link to JIRA)
Added Remove_document_prefix as configuration parameter for backward compatibility and if it is on it will not print record as document object.

# QA steps
 - [ ] automated tests passing
 - [ ] manual QA steps passing (list below)

 
# Risks


# Rollback steps
 - Revert this branch
